### PR TITLE
Update nanossr.ts

### DIFF
--- a/nanossr.ts
+++ b/nanossr.ts
@@ -4,7 +4,9 @@ import {
   Helmet,
   renderSSR as nanoRender,
 } from "https://deno.land/x/nano_jsx@v0.0.30/mod.ts";
+
 import { setup } from "https://esm.sh/twind@0.16.16";
+
 import {
   Configuration,
   getStyleTag,
@@ -13,9 +15,11 @@ import {
   VirtualSheet,
   virtualSheet,
 } from "https://esm.sh/twind@0.16.16/shim/server";
-import typography from "https://esm.sh/@twind/typography@0.0.2";
+
+import typography from "https://cdn.skypack.dev/@twind/typography@0.0.2";
 
 let SHEET_SINGLETON: VirtualSheet | null = null;
+
 function createSheet(twOptions = {}) {
   return SHEET_SINGLETON ??= setupSheet(twOptions);
 }
@@ -27,27 +31,33 @@ function setupSheet(twOptions: Configuration) {
   return sheet;
 }
 
+export type HtmlProps = {
+  body: string;
+  head: string[];
+  footer: string[];
+  styleTag: string;
+  attributes: {
+    html: Map<string, string>;
+    body: Map<string, string>;
+  };
+};
+
 const html = (
-  { body, head, footer, styleTag }: {
-    body: string;
-    head: string[];
-    footer: string[];
-    styleTag: string;
-  },
-) => (`
+  { body, head, footer, styleTag, attributes }: HtmlProps,
+) => (`\
 <!DOCTYPE html>
-<html lang="en">
+<html${attributes.html.size ? ` ${attributes.html}` : ""}>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    ${head.join("\n")}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">\
+    ${head.length ? `\n    ${head.join("")}` : ""}
     ${styleTag}
   </head>
-  <body>
-    ${body}
-    ${footer.join("\n")}
+  <body${attributes.body.size ? ` ${attributes.body}` : ""}>
+    ${body}\
+    ${footer.length ? `\n    ${footer.join("")}` : ""}
   </body>
-<html>
+<html>\
 `);
 
 export interface SSRSettings {
@@ -59,13 +69,18 @@ export interface SSRSettings {
 export function ssr(render: CallableFunction, options?: SSRSettings) {
   const sheet = createSheet(options?.tw ?? {});
   sheet.reset();
-  const app = nanoRender(render(), options);
+
+  const app = nanoRender(render, options);
   shim(app, { tw: options?.tw });
-  const { body, head, footer } = Helmet.SSR(app);
+  const { body, head, footer, attributes } = Helmet.SSR(app);
+
+  if (!attributes.html.has("lang")) {
+    attributes.html.set("lang", "en");
+  }
 
   const styleTag = getStyleTag(sheet);
   return new Response(
-    html({ body, head, footer, styleTag }),
+    html({ body, head, footer, styleTag, attributes }),
     { headers: { "content-type": "text/html" } },
   );
 }


### PR DESCRIPTION
+ Added prop types for generating the HTML content
+ Support for attributes (also if lang is not provided for the HTML tag, the lang="en" is added)
+ Better formatting when head or footer are missing
+ Changed import for typography (for some reason esm.sh is not working but skypack)
+ A bug when rendering simply HTML https://github.com/nanojsx/nano/issues/106